### PR TITLE
feat(update): Sidecar CAS client + full update notes UI

### DIFF
--- a/PCL.Application.Test/LauncherUpdateServiceTests.cs
+++ b/PCL.Application.Test/LauncherUpdateServiceTests.cs
@@ -149,7 +149,9 @@ public sealed class LauncherUpdateServiceTests
                       "channel": "beta",
                       "commitSha": "1234567890abcdef1234567890abcdef12345678",
                       "publishedAt": "2026-08-09T08:00:00Z",
-                      "manifestKey": "releases/v1.4.4-beta"
+                      "manifestKey": "releases/v1.4.4-beta",
+                      "releaseNotes": "- Fix cape wardrobe\n- Improve updater notes",
+                      "releaseNotesUrl": "https://pcln.top/download"
                     }
                     """);
             }
@@ -181,6 +183,8 @@ public sealed class LauncherUpdateServiceTests
         Assert.IsNotNull(result.Package);
         Assert.IsTrue(result.Package.SupportsBlockMap);
         StringAssert.StartsWith(result.Package.BlockMapUrl!, "https://api.pcln.top/v1/updates/releases/");
+        StringAssert.Contains(result.ReleaseNotes, "Fix cape wardrobe");
+        Assert.AreEqual("https://pcln.top/download", result.ReleaseUrl);
     }
 
     [TestMethod]

--- a/PCL.Application.Test/PluginSidecarUpdateServiceTests.cs
+++ b/PCL.Application.Test/PluginSidecarUpdateServiceTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 PCL N contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Text;
+using PCL.Application.Updates;
+
+namespace PCL.Application.Test;
+
+[TestClass]
+public sealed class PluginSidecarUpdateServiceTests
+{
+    [TestMethod]
+    public async Task CheckAsync_ReadsPluginChannelAndReportsNewerVersion()
+    {
+        using HttpClient client = new(new RoutingHandler(request =>
+        {
+            string path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith("/v1/updates/channels/plugin", StringComparison.Ordinal))
+            {
+                return Json("""
+                    {
+                      "tag": "v0.20.1",
+                      "version": "0.20.1",
+                      "channel": "plugin",
+                      "commitSha": "abcdef0123456789abcdef0123456789abcdef01",
+                      "publishedAt": "2026-08-19T04:00:00Z",
+                      "manifestKey": "channels/plugin.json",
+                      "releaseNotes": "- Sidecar mismatch dialog\n- Market DTO mapping"
+                    }
+                    """);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }));
+
+        using PluginSidecarUpdateService service = new(
+            client,
+            distributionBaseUrl: "https://api.pcln.top/v1/updates/releases");
+
+        PluginSidecarUpdateCheckResult result = await service.CheckAsync(
+            new PluginSidecarInstallIdentity("win-x64", "SelfContained", "0.20.0"));
+
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.IsUpdateAvailable);
+        Assert.AreEqual("0.20.1", result.LatestVersion);
+        Assert.AreEqual("v0.20.1", result.ReleaseName);
+        StringAssert.Contains(result.ReleaseNotes, "Sidecar mismatch dialog");
+        StringAssert.Contains(result.PackageUrl, "PCL_Plugin_Sidecar_win-x64_SelfContained.zip");
+        StringAssert.Contains(result.BlockMapUrl, ".blockmap.v2.json");
+    }
+
+    [TestMethod]
+    public async Task CheckAsync_SameVersionIsNotNewer()
+    {
+        using HttpClient client = new(new RoutingHandler(_ => Json("""
+            {
+              "tag": "v0.20.1",
+              "version": "0.20.1",
+              "channel": "plugin",
+              "commitSha": "abcdef0123456789abcdef0123456789abcdef01",
+              "publishedAt": "2026-08-19T04:00:00Z",
+              "manifestKey": "channels/plugin.json"
+            }
+            """)));
+        using PluginSidecarUpdateService service = new(
+            client,
+            distributionBaseUrl: "https://api.pcln.top/v1/updates/releases");
+
+        PluginSidecarUpdateCheckResult result = await service.CheckAsync(
+            new PluginSidecarInstallIdentity(
+                "win-x64",
+                "SelfContained",
+                "0.20.1",
+                "abcdef0123456789abcdef0123456789abcdef01"));
+
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.IsUpdateAvailable);
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class RoutingHandler(Func<HttpRequestMessage, HttpResponseMessage> handle) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(handle(request));
+    }
+}

--- a/PCL.Application.Test/PluginSidecarUpdateServiceTests.cs
+++ b/PCL.Application.Test/PluginSidecarUpdateServiceTests.cs
@@ -47,7 +47,9 @@ public sealed class PluginSidecarUpdateServiceTests
         Assert.AreEqual("v0.20.1", result.ReleaseName);
         StringAssert.Contains(result.ReleaseNotes, "Sidecar mismatch dialog");
         StringAssert.Contains(result.PackageUrl, "PCL_Plugin_Sidecar_win-x64_SelfContained.zip");
-        StringAssert.Contains(result.BlockMapUrl, ".blockmap.v2.json");
+        Assert.IsFalse(
+            result.PackageUrl!.Contains("blockmap", StringComparison.OrdinalIgnoreCase),
+            "Sidecar updates must be full-package URLs without block maps.");
     }
 
     [TestMethod]

--- a/PCL.Application/Updates/LauncherUpdateJsonContext.cs
+++ b/PCL.Application/Updates/LauncherUpdateJsonContext.cs
@@ -58,6 +58,10 @@ internal sealed class LauncherChannelReleaseDto
     public DateTimeOffset? PublishedAt { get; set; }
 
     public string? ManifestKey { get; set; }
+
+    public string? ReleaseNotes { get; set; }
+
+    public string? ReleaseNotesUrl { get; set; }
 }
 
 internal sealed class GitHubReleaseDto

--- a/PCL.Application/Updates/LauncherUpdateService.Discovery.cs
+++ b/PCL.Application/Updates/LauncherUpdateService.Discovery.cs
@@ -99,14 +99,22 @@ public sealed partial class LauncherUpdateService
             };
         }
 
+        string? releaseNotes = string.IsNullOrWhiteSpace(marker.ReleaseNotes)
+            ? null
+            : marker.ReleaseNotes.Trim();
+        string releaseUrl = !string.IsNullOrWhiteSpace(marker.ReleaseNotesUrl) &&
+                            Uri.TryCreate(marker.ReleaseNotesUrl.Trim(), UriKind.Absolute, out Uri? notesUri) &&
+                            notesUri.Scheme == Uri.UriSchemeHttps
+            ? notesUri.AbsoluteUri
+            : "https://pcln.top/download";
         LauncherUpdateCheckResult result = new(
             Success: true,
             IsUpdateAvailable: isNewer,
             CurrentVersion: localVersion,
             LatestVersion: remoteVersion,
             ReleaseName: marker.Tag,
-            ReleaseNotes: null,
-            ReleaseUrl: "https://pcln.top/download",
+            ReleaseNotes: releaseNotes,
+            ReleaseUrl: releaseUrl,
             PreferredAssetUrl: package.FullPackageUrl,
             ErrorMessage: null,
             Channel: channel,

--- a/PCL.Application/Updates/PluginSidecarUpdateModels.cs
+++ b/PCL.Application/Updates/PluginSidecarUpdateModels.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 PCL N contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace PCL.Application.Updates;
+
+/// <summary>
+/// Independent PCL.Plugin Sidecar update check result (sibling of launcher updates).
+/// </summary>
+public sealed record PluginSidecarUpdateCheckResult(
+    bool Success,
+    bool IsUpdateAvailable,
+    string? CurrentVersion,
+    string? LatestVersion,
+    string? ReleaseName,
+    string? ReleaseNotes,
+    string? ReleaseUrl,
+    string? PackageUrl,
+    string? PackageSha256,
+    long? PackageSize,
+    string? BlockMapUrl,
+    string? ErrorMessage,
+    string? RemoteCommitSha,
+    DateTimeOffset? PublishedAt,
+    string Channel = "plugin")
+{
+    public static PluginSidecarUpdateCheckResult Failed(string message) =>
+        new(
+            Success: false,
+            IsUpdateAvailable: false,
+            CurrentVersion: null,
+            LatestVersion: null,
+            ReleaseName: null,
+            ReleaseNotes: null,
+            ReleaseUrl: null,
+            PackageUrl: null,
+            PackageSha256: null,
+            PackageSize: null,
+            BlockMapUrl: null,
+            ErrorMessage: message,
+            RemoteCommitSha: null,
+            PublishedAt: null);
+}
+
+public sealed record PluginSidecarInstallIdentity(
+    string RuntimeId,
+    string RuntimeVariant,
+    string CurrentVersion,
+    string? CurrentCommitSha = null);

--- a/PCL.Application/Updates/PluginSidecarUpdateModels.cs
+++ b/PCL.Application/Updates/PluginSidecarUpdateModels.cs
@@ -17,7 +17,6 @@ public sealed record PluginSidecarUpdateCheckResult(
     string? PackageUrl,
     string? PackageSha256,
     long? PackageSize,
-    string? BlockMapUrl,
     string? ErrorMessage,
     string? RemoteCommitSha,
     DateTimeOffset? PublishedAt,
@@ -35,7 +34,6 @@ public sealed record PluginSidecarUpdateCheckResult(
             PackageUrl: null,
             PackageSha256: null,
             PackageSize: null,
-            BlockMapUrl: null,
             ErrorMessage: message,
             RemoteCommitSha: null,
             PublishedAt: null);

--- a/PCL.Application/Updates/PluginSidecarUpdateService.cs
+++ b/PCL.Application/Updates/PluginSidecarUpdateService.cs
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 PCL N contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using PCL.Application.Online;
+using PCL.Core.Logging;
+
+namespace PCL.Application.Updates;
+
+/// <summary>
+/// Checks the Cloudflare <c>plugin</c> channel for independent PCL.Plugin Sidecar CAS updates.
+/// Shares mTLS transport conventions with <see cref="LauncherUpdateService"/> but stays a sibling.
+/// </summary>
+public sealed class PluginSidecarUpdateService : IDisposable
+{
+    public const string DefaultChannel = "plugin";
+
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsClient;
+    private readonly string _releasesBaseUrl;
+    private readonly string _channelBaseUrl;
+    private bool _disposed;
+
+    public PluginSidecarUpdateService(HttpClient? httpClient = null, string? distributionBaseUrl = null)
+    {
+        if (httpClient is null)
+        {
+            _httpClient = PclnApiHttpClientFactory.Create(
+                allowAutoRedirect: false,
+                timeout: TimeSpan.FromSeconds(30));
+            _ownsClient = true;
+        }
+        else
+        {
+            _httpClient = httpClient;
+            _ownsClient = false;
+        }
+
+        string configured = distributionBaseUrl
+            ?? Environment.GetEnvironmentVariable("PCLN_UPDATE_DISTRIBUTION_BASE_URL")
+            ?? "https://api.pcln.top/v1/updates/releases";
+        _releasesBaseUrl = configured.TrimEnd('/');
+        _channelBaseUrl = _releasesBaseUrl.EndsWith("/releases", StringComparison.OrdinalIgnoreCase)
+            ? _releasesBaseUrl[..^"/releases".Length] + "/channels"
+            : _releasesBaseUrl + "/channels";
+
+        if (_httpClient.DefaultRequestHeaders.UserAgent.Count == 0)
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PCL-N", "1.0"));
+        if (_httpClient.DefaultRequestHeaders.Accept.Count == 0)
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+
+    public async Task<PluginSidecarUpdateCheckResult> CheckAsync(
+        PluginSidecarInstallIdentity identity,
+        string channel = DefaultChannel,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(identity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity.CurrentVersion);
+
+        string normalizedChannel = string.IsNullOrWhiteSpace(channel)
+            ? DefaultChannel
+            : channel.Trim().ToLowerInvariant();
+        if (normalizedChannel is not ("plugin" or "plugin-beta"))
+            return PluginSidecarUpdateCheckResult.Failed("不支持的 Sidecar 更新通道：" + normalizedChannel);
+
+        string url =
+            $"{_channelBaseUrl}/{normalizedChannel}?check={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+        LauncherChannelReleaseDto marker;
+        try
+        {
+            using HttpResponseMessage response = await GetFollowingRedirectsAsync(url, cancellationToken)
+                .ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return PluginSidecarUpdateCheckResult.Failed("Cloudflare 尚未发布 Sidecar 更新通道。");
+            if (!response.IsSuccessStatusCode)
+                return PluginSidecarUpdateCheckResult.Failed(
+                    $"Cloudflare Sidecar 更新通道不可用 ({(int)response.StatusCode})。");
+
+            await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
+                .ConfigureAwait(false);
+            marker = await JsonSerializer.DeserializeAsync(
+                    stream,
+                    LauncherUpdateJsonContext.Default.LauncherChannelReleaseDto,
+                    cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new InvalidDataException("Sidecar 更新通道返回了空清单。");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            PortableLog.Warn(ex, "PluginSidecarUpdate", "读取 Sidecar 更新通道失败。");
+            return PluginSidecarUpdateCheckResult.Failed("无法读取 Sidecar 更新通道：" + ex.Message);
+        }
+
+        if (string.IsNullOrWhiteSpace(marker.Tag) ||
+            string.IsNullOrWhiteSpace(marker.Version) ||
+            marker.PublishedAt is null)
+        {
+            return PluginSidecarUpdateCheckResult.Failed("Sidecar 更新通道清单无效。");
+        }
+
+        string remoteVersion = NormalizeVersion(marker.Version);
+        string localVersion = NormalizeVersion(identity.CurrentVersion);
+        string remoteCommit = NormalizeCommit(marker.CommitSha);
+        string localCommit = NormalizeCommit(identity.CurrentCommitSha);
+        bool sameCommit = AreKnownCommitsEqual(localCommit, remoteCommit);
+        bool isNewer = CompareVersions(remoteVersion, localVersion) > 0 && !sameCommit;
+
+        string assetStem = BuildAssetStem(identity.RuntimeId, identity.RuntimeVariant);
+        string packageUrl = $"{_releasesBaseUrl}/{Uri.EscapeDataString(marker.Tag)}/{assetStem}.zip";
+        string blockMapUrl = $"{_releasesBaseUrl}/{Uri.EscapeDataString(marker.Tag)}/{assetStem}.blockmap.v2.json";
+        string? notes = string.IsNullOrWhiteSpace(marker.ReleaseNotes) ? null : marker.ReleaseNotes.Trim();
+        string releaseUrl = !string.IsNullOrWhiteSpace(marker.ReleaseNotesUrl) &&
+                            Uri.TryCreate(marker.ReleaseNotesUrl.Trim(), UriKind.Absolute, out Uri? notesUri) &&
+                            notesUri.Scheme == Uri.UriSchemeHttps
+            ? notesUri.AbsoluteUri
+            : $"https://github.com/PCL-N-Edition/PCL.Plugin/releases/tag/{Uri.EscapeDataString(marker.Tag)}";
+
+        PortableLog.Info(
+            "PluginSidecarUpdate",
+            $"Sidecar 更新检查完成；通道={normalizedChannel}；本地={localVersion}；远端={remoteVersion}；有更新={isNewer}。");
+
+        return new PluginSidecarUpdateCheckResult(
+            Success: true,
+            IsUpdateAvailable: isNewer,
+            CurrentVersion: localVersion,
+            LatestVersion: remoteVersion,
+            ReleaseName: marker.Tag,
+            ReleaseNotes: notes,
+            ReleaseUrl: releaseUrl,
+            PackageUrl: packageUrl,
+            PackageSha256: null,
+            PackageSize: null,
+            BlockMapUrl: blockMapUrl,
+            ErrorMessage: null,
+            RemoteCommitSha: string.IsNullOrWhiteSpace(remoteCommit) ? null : remoteCommit,
+            PublishedAt: marker.PublishedAt,
+            Channel: normalizedChannel);
+    }
+
+    public async Task DownloadPackageAsync(
+        string packageUrl,
+        string destinationPath,
+        IProgress<double>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageUrl);
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+
+        string? directory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        using HttpResponseMessage response = await GetFollowingRedirectsAsync(packageUrl, cancellationToken)
+            .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"下载 Sidecar 更新包失败：{(int)response.StatusCode} {response.ReasonPhrase}",
+                null,
+                response.StatusCode);
+        }
+
+        long? total = response.Content.Headers.ContentLength;
+        await using Stream network = await response.Content.ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using FileStream file = new(
+            destinationPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            64 * 1024,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        byte[] buffer = new byte[64 * 1024];
+        long copied = 0;
+        while (true)
+        {
+            int read = await network.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+                .ConfigureAwait(false);
+            if (read <= 0)
+                break;
+            await file.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            copied += read;
+            if (total is > 0)
+                progress?.Report(Math.Clamp(copied / (double)total.Value, 0d, 1d));
+        }
+
+        progress?.Report(1d);
+    }
+
+    public static string ResolveRuntimeId()
+    {
+        if (OperatingSystem.IsWindows())
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "win-arm64" : "win-x64";
+        if (OperatingSystem.IsLinux())
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "linux-arm64" : "linux-x64";
+        if (OperatingSystem.IsMacOS())
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
+        return "win-x64";
+    }
+
+    public static string BuildAssetStem(string runtimeId, string runtimeVariant)
+    {
+        string rid = string.IsNullOrWhiteSpace(runtimeId) ? ResolveRuntimeId() : runtimeId.Trim();
+        string variant = string.Equals(runtimeVariant, "NoRuntime", StringComparison.OrdinalIgnoreCase)
+            ? "NoRuntime"
+            : "SelfContained";
+        return $"PCL_Plugin_Sidecar_{rid}_{variant}";
+    }
+
+    private async Task<HttpResponseMessage> GetFollowingRedirectsAsync(
+        string url,
+        CancellationToken cancellationToken)
+    {
+        string current = url;
+        for (int redirect = 0; redirect < 6; redirect++)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Get, current);
+            HttpResponseMessage response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!IsRedirect(response.StatusCode) || response.Headers.Location is null)
+                return response;
+
+            Uri next = response.Headers.Location.IsAbsoluteUri
+                ? response.Headers.Location
+                : new Uri(new Uri(current), response.Headers.Location);
+            response.Dispose();
+            if (!string.Equals(next.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Sidecar 更新重定向到了非 HTTPS 地址。");
+            current = next.AbsoluteUri;
+        }
+
+        throw new InvalidOperationException("Sidecar 更新地址重定向次数过多。");
+    }
+
+    private static bool IsRedirect(HttpStatusCode code) =>
+        code is HttpStatusCode.Moved or HttpStatusCode.Redirect or HttpStatusCode.RedirectMethod
+            or HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect
+            or HttpStatusCode.Found or HttpStatusCode.SeeOther;
+
+    private static string NormalizeVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return string.Empty;
+        string trimmed = version.Trim();
+        return trimmed.StartsWith('v') || trimmed.StartsWith('V') ? trimmed[1..] : trimmed;
+    }
+
+    private static string NormalizeCommit(string? commit) =>
+        string.IsNullOrWhiteSpace(commit) ? string.Empty : commit.Trim().ToLowerInvariant();
+
+    private static bool AreKnownCommitsEqual(string left, string right) =>
+        left.Length >= 7 && right.Length >= 7 &&
+        (left.StartsWith(right, StringComparison.Ordinal) || right.StartsWith(left, StringComparison.Ordinal));
+
+    private static int CompareVersions(string left, string right)
+    {
+        if (!Version.TryParse(StripPrerelease(left), out Version? leftVersion))
+            leftVersion = new Version(0, 0, 0);
+        if (!Version.TryParse(StripPrerelease(right), out Version? rightVersion))
+            rightVersion = new Version(0, 0, 0);
+        int core = leftVersion.CompareTo(rightVersion);
+        if (core != 0)
+            return core;
+        bool leftPre = left.Contains('-', StringComparison.Ordinal);
+        bool rightPre = right.Contains('-', StringComparison.Ordinal);
+        if (leftPre == rightPre)
+            return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+        return leftPre ? -1 : 1;
+    }
+
+    private static string StripPrerelease(string version)
+    {
+        int dash = version.IndexOf('-');
+        return dash < 0 ? version : version[..dash];
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        if (_ownsClient)
+            _httpClient.Dispose();
+    }
+}

--- a/PCL.Application/Updates/PluginSidecarUpdateService.cs
+++ b/PCL.Application/Updates/PluginSidecarUpdateService.cs
@@ -116,7 +116,7 @@ public sealed class PluginSidecarUpdateService : IDisposable
 
         string assetStem = BuildAssetStem(identity.RuntimeId, identity.RuntimeVariant);
         string packageUrl = $"{_releasesBaseUrl}/{Uri.EscapeDataString(marker.Tag)}/{assetStem}.zip";
-        string blockMapUrl = $"{_releasesBaseUrl}/{Uri.EscapeDataString(marker.Tag)}/{assetStem}.blockmap.v2.json";
+        // Sidecar updates are full-package only on CF (no FastCDC / block maps).
         string? notes = string.IsNullOrWhiteSpace(marker.ReleaseNotes) ? null : marker.ReleaseNotes.Trim();
         string releaseUrl = !string.IsNullOrWhiteSpace(marker.ReleaseNotesUrl) &&
                             Uri.TryCreate(marker.ReleaseNotesUrl.Trim(), UriKind.Absolute, out Uri? notesUri) &&
@@ -126,7 +126,7 @@ public sealed class PluginSidecarUpdateService : IDisposable
 
         PortableLog.Info(
             "PluginSidecarUpdate",
-            $"Sidecar 更新检查完成；通道={normalizedChannel}；本地={localVersion}；远端={remoteVersion}；有更新={isNewer}。");
+            $"Sidecar 更新检查完成；通道={normalizedChannel}；本地={localVersion}；远端={remoteVersion}；有更新={isNewer}；交付=整包。");
 
         return new PluginSidecarUpdateCheckResult(
             Success: true,
@@ -139,7 +139,6 @@ public sealed class PluginSidecarUpdateService : IDisposable
             PackageUrl: packageUrl,
             PackageSha256: null,
             PackageSize: null,
-            BlockMapUrl: blockMapUrl,
             ErrorMessage: null,
             RemoteCommitSha: string.IsNullOrWhiteSpace(remoteCommit) ? null : remoteCommit,
             PublishedAt: marker.PublishedAt,

--- a/PCL.Application/Updates/README.md
+++ b/PCL.Application/Updates/README.md
@@ -5,7 +5,7 @@
 ## 处理流程
 
 1. `LauncherUpdateService` 根据更新通道检查新版本，并返回一个不可变的 `LauncherUpdateCheckResult`。
-2. `LauncherUpdateService.Discovery` 从要求 mTLS 的 Cloudflare 通道端点发现 Release、Beta 或滚动 CI 构建；通道 JSON 可带 `releaseNotes` / `releaseNotesUrl` 供更新页展示。独立 **PCL.Plugin Sidecar** 通道（`channels/plugin.json`）由 sibling 服务消费，不混入本目录的宿主业务语义。
+2. `LauncherUpdateService.Discovery` 从要求 mTLS 的 Cloudflare 通道端点发现 Release、Beta 或滚动 CI 构建；通道 JSON 可带 `releaseNotes` / `releaseNotesUrl` 供更新页展示。独立 **PCL.Plugin Sidecar** 通道（`channels/plugin.json`）由 sibling 服务消费，**整包 zip 交付、不分块**，不混入本目录的宿主 FastCDC 业务语义。
 3. `LauncherUpdateService.Packages` 选择当前 RID 和运行时变体对应的逻辑更新包；1.4.3 及更新版本必须使用已签名的内容寻址分块图。
 4. `LauncherUpdateService.Transport` 统一处理元数据请求、安全重定向和内容长度探测。
 5. `LauncherUpdateInstaller` 下载、校验并准备更新；`LauncherBlockUpdateInstaller` 查找本地重复块、下载缺块并重组文件；`LauncherScatterUpdateInstaller` 负责散包清单与替换计划。

--- a/PCL.Application/Updates/README.md
+++ b/PCL.Application/Updates/README.md
@@ -5,7 +5,7 @@
 ## 处理流程
 
 1. `LauncherUpdateService` 根据更新通道检查新版本，并返回一个不可变的 `LauncherUpdateCheckResult`。
-2. `LauncherUpdateService.Discovery` 从要求 mTLS 的 Cloudflare 通道端点发现 Release、Beta 或滚动 CI 构建。
+2. `LauncherUpdateService.Discovery` 从要求 mTLS 的 Cloudflare 通道端点发现 Release、Beta 或滚动 CI 构建；通道 JSON 可带 `releaseNotes` / `releaseNotesUrl` 供更新页展示。独立 **PCL.Plugin Sidecar** 通道（`channels/plugin.json`）由 sibling 服务消费，不混入本目录的宿主业务语义。
 3. `LauncherUpdateService.Packages` 选择当前 RID 和运行时变体对应的逻辑更新包；1.4.3 及更新版本必须使用已签名的内容寻址分块图。
 4. `LauncherUpdateService.Transport` 统一处理元数据请求、安全重定向和内容长度探测。
 5. `LauncherUpdateInstaller` 下载、校验并准备更新；`LauncherBlockUpdateInstaller` 查找本地重复块、下载缺块并重组文件；`LauncherScatterUpdateInstaller` 负责散包清单与替换计划。

--- a/PCL.Desktop.Test/DesktopArchitectureTests.cs
+++ b/PCL.Desktop.Test/DesktopArchitectureTests.cs
@@ -298,6 +298,8 @@ public sealed class DesktopArchitectureTests
         string[] unreferenced = english.Keys
             .Where(key => !key.StartsWith("Localization.Meta.", StringComparison.Ordinal))
             .Where(key => !key.StartsWith("Plugin.", StringComparison.Ordinal))
+            // Built at runtime from Mojang cape aliases in ResolveMicrosoftCapeDisplayName.
+            .Where(key => !key.StartsWith("Appearance.Cape.Name.", StringComparison.Ordinal))
             .Where(key => !sourceTexts.Any(source => source.Contains(key, StringComparison.Ordinal)))
             .ToArray();
 

--- a/PCL.Desktop/Controls/Legacy/MyMsgMarkdown.axaml
+++ b/PCL.Desktop/Controls/Legacy/MyMsgMarkdown.axaml
@@ -47,7 +47,7 @@
                                    VerticalAlignment="Stretch"
                                    Margin="0,0,0,17"
                                    Padding="0,0,7,0"
-                                   MaxHeight="320"
+                                   MaxHeight="480"
                                    VerticalScrollBarVisibility="Auto"
                                    HorizontalScrollBarVisibility="Disabled">
                 <legacy:MyMarkdownViewer x:Name="LabCaption"

--- a/PCL.Desktop/Features/Settings/Views/PageSetupUpdate.axaml
+++ b/PCL.Desktop/Features/Settings/Views/PageSetupUpdate.axaml
@@ -63,15 +63,16 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="29" />
                             <RowDefinition Height="1" />
-                            <RowDefinition Height="20" />
+                            <RowDefinition Height="Auto" MinHeight="20" />
                         </Grid.RowDefinitions>
                         <legacy:MyImage Source="avares://PCL.Desktop/Assets/icon.png" Grid.Column="0" Grid.Row="0"
                                        Grid.RowSpan="3" Height="50" Width="50" HorizontalAlignment="Left"
                                        VerticalAlignment="Center" />
                         <TextBlock x:Name="TextCurrentVersion" Text="PCL N" FontWeight="Bold" FontSize="20"
-                                   Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
+                                   Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Bottom"
+                                   TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
                         <TextBlock x:Name="TextCurrentDesc" Text="{DynamicResource Setup.Update.Latest}" FontSize="14" Grid.Row="2" Grid.Column="2"
-                                   HorizontalAlignment="Left" VerticalAlignment="Top" />
+                                   HorizontalAlignment="Left" VerticalAlignment="Top" TextWrapping="Wrap" />
                         <legacy:MyButton x:Name="BtnCheckAgain" Text="{DynamicResource Setup.Update.CheckAgain}" ColorType="Highlight" Grid.Row="0"
                                         Grid.RowSpan="2" Grid.Column="3" HorizontalAlignment="Stretch"
                                         VerticalAlignment="Stretch" Click="BtnCheckAgain_OnClick" />
@@ -97,19 +98,20 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="29" />
                             <RowDefinition Height="1" />
-                            <RowDefinition Height="20" />
+                            <RowDefinition Height="Auto" MinHeight="20" />
                             <RowDefinition Height="8" />
-                            <RowDefinition />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="10" />
-                            <RowDefinition />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <legacy:MyImage x:Name="ImgUpdateIcon" Source="avares://PCL.Desktop/Assets/icon.png"
                                        Grid.Column="0" Grid.Row="0" Grid.RowSpan="3" Height="50" Width="50"
                                        HorizontalAlignment="Left" VerticalAlignment="Center" />
                         <TextBlock x:Name="TextUpdateName" Text="PCL N" FontWeight="Bold" FontSize="20"
-                                   Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
+                                   Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Bottom"
+                                   TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
                         <TextBlock x:Name="TextUpdateDesc" Text="{DynamicResource Setup.Update.Available}" FontSize="14" Grid.Row="2"
-                                   Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                                   Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Top" TextWrapping="Wrap" />
                         <legacy:MyButton x:Name="BtnDownloadNow" Text="{DynamicResource Setup.Update.DownloadNow}" ColorType="Normal"
                                         Grid.Row="0" Grid.RowSpan="2" Grid.Column="3"
                                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch"

--- a/PCL.Desktop/Features/Settings/Views/PageSetupUpdate.axaml.cs
+++ b/PCL.Desktop/Features/Settings/Views/PageSetupUpdate.axaml.cs
@@ -11,8 +11,10 @@ using Avalonia.VisualTree;
 using PCL.Application.Settings;
 using PCL.Application.Updates;
 using PCL.Core.App;
+using PCL.Core.Logging;
 using PCL.Desktop.Controls.Legacy;
 using PCL.Desktop.Hosting;
+using PCL.Desktop.Hosting.PluginSidecar;
 using PCL.Desktop.Localization;
 
 #pragma warning disable CA1822, CS0067
@@ -33,10 +35,13 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
     private bool _autoCheckScheduled;
     private int _lastUpdateChannel;
     private readonly LauncherUpdateCoordinator _updateCoordinator = LauncherUpdateCoordinator.Current;
+    private readonly PluginSidecarUpdateCoordinator _pluginUpdateCoordinator = PluginSidecarUpdateCoordinator.Current;
     private readonly LauncherInstallationContext _installation = LauncherInstallationContext.Detect();
     private LauncherUpdateCheckResult? _availableUpdate;
+    private PluginSidecarUpdateCheckResult? _availablePluginUpdate;
     private PreparedLauncherUpdate? _preparedUpdate;
     private bool _isPreparingUpdate;
+    private bool _showingPluginUpdate;
 
     public PageSetupUpdate()
     {
@@ -191,6 +196,8 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
     private void ShowCurrentVersionUi()
     {
         _updateAvailableUi = false;
+        _showingPluginUpdate = false;
+        _availablePluginUpdate = null;
         if (this.FindControl<MyCard>("CardUpdate") is { } updateCard)
             updateCard.IsVisible = false;
 
@@ -291,6 +298,13 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
 
     private async void BtnDownloadNow_Click(object? sender, EventArgs e)
     {
+        if (_showingPluginUpdate)
+        {
+            // Download-only mode for Sidecar still installs (no staged host restart).
+            await ProcessAvailablePluginUpdateAsync(mode: 1).ConfigureAwait(true);
+            return;
+        }
+
         if (_preparedUpdate is not null && _availableUpdate is not null)
         {
             _updateCoordinator.SkipAvailableVersion(_availableUpdate);
@@ -319,6 +333,12 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
 
     private async Task InstallOrPrepareUpdateAsync()
     {
+        if (_showingPluginUpdate)
+        {
+            await ProcessAvailablePluginUpdateAsync(mode: 0).ConfigureAwait(true);
+            return;
+        }
+
         _isPreparingUpdate = true;
         SetUpdateButtonsEnabled(false);
         try
@@ -541,6 +561,8 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
         }
 
         _availableUpdate = result.IsUpdateAvailable ? result : null;
+        _availablePluginUpdate = null;
+        _showingPluginUpdate = false;
         _preparedUpdate = _updateCoordinator.PreparedUpdate;
         if (_preparedUpdate?.Package.TargetTag != result.Package?.TargetTag)
             _preparedUpdate = null;
@@ -552,25 +574,34 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
 
         if (!result.IsUpdateAvailable)
         {
+            // Host body is current — only then surface independent Sidecar ("插件功能更新") cards.
             _availableUpdate = null;
             _preferredAssetUrl = null;
+            if (await TryShowPluginSidecarUpdateAsync(automaticallyPrepare).ConfigureAwait(true))
+                return;
+
             ShowCurrentVersionUi();
             if (this.FindControl<TextBlock>("TextCurrentDesc") is { } currentDesc)
             {
                 string latest = AvaloniaLocalizationManager.GetText("Setup.Update.Latest", "已是最新版本");
-                currentDesc.Text = string.IsNullOrWhiteSpace(result.CurrentVersion)
+                string sidecar = DescribeSidecarVersion();
+                string body = string.IsNullOrWhiteSpace(result.CurrentVersion)
                     ? latest + " · " + DescribeCurrentBuild()
                     : $"{latest}（{result.CurrentVersion}） · {DescribeCurrentBuild()}";
+                if (!string.IsNullOrWhiteSpace(sidecar))
+                    body += " · " + sidecar;
+                currentDesc.Text = body;
             }
             return;
         }
 
         if (this.FindControl<TextBlock>("TextUpdateName") is { } updateName)
-            updateName.Text = "PCL N " + (result.LatestVersion ?? "");
+            updateName.Text = AvaloniaLocalizationManager.GetText("Setup.Update.Product.Host", "PCL N 软件更新") +
+                              " " + (result.LatestVersion ?? "");
         if (this.FindControl<TextBlock>("TextUpdateDesc") is { } updateDesc)
         {
             updateDesc.Text = _preparedUpdate is not null
-                ? "更新已下载并通过校验"
+                ? AvaloniaLocalizationManager.GetText("Setup.Update.Downloaded", "更新已下载并通过校验")
                 : result.Channel is UpdateChannel.CI
                     ? (result.ReleaseName ?? "CI") + " · " + AvaloniaLocalizationManager.GetText("Setup.Update.Available", "有可用更新")
                     : AvaloniaLocalizationManager.GetText("Setup.Update.Available", "有可用更新");
@@ -617,14 +648,107 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
             await ProcessAvailableUpdateAsync(updateMode).ConfigureAwait(true);
     }
 
+    /// <summary>
+    /// When the host body has no update, reuse the same CardUpdate chrome for Sidecar CAS.
+    /// Returns true when a plugin update card was shown.
+    /// </summary>
+    private async Task<bool> TryShowPluginSidecarUpdateAsync(bool automaticallyPrepare)
+    {
+        PluginSidecarUpdateCheckResult plugin;
+        try
+        {
+            plugin = await _pluginUpdateCoordinator.CheckAsync().ConfigureAwait(true);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            PortableLog.Warn(ex, "PluginSidecarUpdate", "检查 Sidecar 更新失败。");
+            return false;
+        }
+
+        if (!plugin.Success || !plugin.IsUpdateAvailable)
+            return false;
+
+        _showingPluginUpdate = true;
+        _availablePluginUpdate = plugin;
+        _availableUpdate = null;
+        _preparedUpdate = null;
+        _latestReleaseUrl = plugin.ReleaseUrl ?? ReleasesUrl;
+        _preferredAssetUrl = plugin.PackageUrl;
+        SetUpdateActionButtons(prepared: false);
+        SetUpdateButtonsEnabled(true);
+        SetUpdateButtonsVisible(true);
+
+        if (this.FindControl<TextBlock>("TextUpdateName") is { } updateName)
+        {
+            updateName.Text = AvaloniaLocalizationManager.GetText(
+                                  "Setup.Update.Product.Plugin",
+                                  "插件功能更新") +
+                              " " + (plugin.LatestVersion ?? "");
+        }
+
+        if (this.FindControl<TextBlock>("TextUpdateDesc") is { } updateDesc)
+        {
+            updateDesc.Text = AvaloniaLocalizationManager.GetText(
+                "Setup.Update.Plugin.Available",
+                "有可用的 PCL.Plugin Sidecar 更新（不替换 PCL N 本体）");
+        }
+
+        if (this.FindControl<TextBlock>("TextChangelog") is { } changelog)
+        {
+            changelog.Text = !string.IsNullOrWhiteSpace(plugin.ReleaseNotes)
+                ? plugin.ReleaseNotes.Trim()
+                : AvaloniaLocalizationManager.GetText(
+                    "Setup.Update.Plugin.Changelog.Placeholder",
+                    "此更新仅升级插件侧车与插件平台能力，不会替换 Native AOT 宿主程序。");
+        }
+
+        ShowUpdateAvailableUi();
+        if (!automaticallyPrepare)
+            return true;
+
+        int updateMode = this.FindControl<MyComboBox>("ComboSystemUpdateMode") is { SelectedIndex: >= 0 } modeCombo
+            ? modeCombo.SelectedIndex
+            : LauncherSettingDefaults.GetInteger("SystemUpdateMode", 1);
+        // Notify-only (2) still shows the card; download modes trigger Sidecar CAS install.
+        if (updateMode is 0 or 1)
+            await ProcessAvailablePluginUpdateAsync(updateMode).ConfigureAwait(true);
+        return true;
+    }
+
     private void SetCurrentVersionText()
     {
         string version = "PCL N " + PclMetadata.Current.DisplayVersion;
         if (this.FindControl<TextBlock>("TextCurrentVersion") is { } currentVersion)
             currentVersion.Text = version;
         if (this.FindControl<TextBlock>("TextCurrentDesc") is { } currentDescription && !_isChecking && !_updateAvailableUi)
-            currentDescription.Text = AvaloniaLocalizationManager.GetText("Setup.Update.Latest", "已是最新版本") +
-                                      " · " + DescribeCurrentBuild();
+        {
+            string text = AvaloniaLocalizationManager.GetText("Setup.Update.Latest", "已是最新版本") +
+                          " · " + DescribeCurrentBuild();
+            string sidecar = DescribeSidecarVersion();
+            if (!string.IsNullOrWhiteSpace(sidecar))
+                text += " · " + sidecar;
+            currentDescription.Text = text;
+        }
+    }
+
+    private static string DescribeSidecarVersion()
+    {
+        try
+        {
+            PluginSidecarInstallIdentity identity = PluginSidecarUpdateInstaller.ResolveLocalIdentity();
+            if (string.IsNullOrWhiteSpace(identity.CurrentVersion) ||
+                identity.CurrentVersion is "0.0.0")
+            {
+                return string.Empty;
+            }
+
+            return AvaloniaLocalizationManager.GetText("Setup.Update.Plugin.Current", "插件") +
+                   " " + identity.CurrentVersion;
+        }
+        catch
+        {
+            return string.Empty;
+        }
     }
 
     private async Task ProcessAvailableUpdateAsync(
@@ -633,6 +757,12 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
     {
         if (_isPreparingUpdate)
             return;
+        if (_showingPluginUpdate)
+        {
+            await ProcessAvailablePluginUpdateAsync(mode, cancellationToken).ConfigureAwait(true);
+            return;
+        }
+
         if (_availableUpdate?.Package is null)
         {
             OpenUrlRequested?.Invoke(this, new SettingsUrlRequestedEventArgs(_preferredAssetUrl ?? _latestReleaseUrl));
@@ -656,6 +786,87 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
                 new SettingsMessageRequestedEventArgs(
                     "自动更新失败",
                     ex.Message + "\n\n你仍可在发布页手动下载。",
+                    AvaloniaLocalizationManager.GetText("Common.Action.Confirm", "好")));
+        }
+        finally
+        {
+            _isPreparingUpdate = false;
+            SetUpdateButtonsEnabled(true);
+        }
+    }
+
+    private async Task ProcessAvailablePluginUpdateAsync(
+        int mode,
+        CancellationToken cancellationToken = default)
+    {
+        if (_isPreparingUpdate || _availablePluginUpdate is null)
+            return;
+
+        // mode 2 = notify only — card already visible.
+        if (mode == 2)
+            return;
+
+        _isPreparingUpdate = true;
+        SetUpdateButtonsEnabled(false);
+        try
+        {
+            if (this.FindControl<TextBlock>("TextUpdateDesc") is { } description)
+            {
+                description.Text = AvaloniaLocalizationManager.GetText(
+                    "Setup.Update.Plugin.Downloading",
+                    "正在下载插件功能更新…");
+            }
+
+            Progress<double> progress = new(value =>
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (this.FindControl<TextBlock>("TextUpdateDesc") is { } live)
+                    {
+                        live.Text = AvaloniaLocalizationManager.GetText(
+                                        "Setup.Update.Plugin.Downloading",
+                                        "正在下载插件功能更新…") +
+                                    $" {value:P0}";
+                    }
+                });
+            });
+
+            await _pluginUpdateCoordinator
+                .DownloadAndInstallAsync(_availablePluginUpdate, progress, cancellationToken)
+                .ConfigureAwait(true);
+
+            _availablePluginUpdate = null;
+            _showingPluginUpdate = false;
+            ShowCurrentVersionUi();
+            if (this.FindControl<TextBlock>("TextCurrentDesc") is { } done)
+            {
+                done.Text = AvaloniaLocalizationManager.GetText(
+                    "Setup.Update.Plugin.Installed",
+                    "插件功能更新已安装并尝试重启侧车。");
+            }
+
+            if (mode == 0)
+            {
+                MessageRequested?.Invoke(
+                    this,
+                    new SettingsMessageRequestedEventArgs(
+                        AvaloniaLocalizationManager.GetText("Setup.Update.Product.Plugin", "插件功能更新"),
+                        AvaloniaLocalizationManager.GetText(
+                            "Setup.Update.Plugin.Installed",
+                            "插件功能更新已安装并尝试重启侧车。"),
+                        AvaloniaLocalizationManager.GetText("Common.Action.Confirm", "好")));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            MessageRequested?.Invoke(
+                this,
+                new SettingsMessageRequestedEventArgs(
+                    AvaloniaLocalizationManager.GetText("Setup.Update.Plugin.Failed", "插件功能更新失败"),
+                    ex.Message,
                     AvaloniaLocalizationManager.GetText("Common.Action.Confirm", "好")));
         }
         finally

--- a/PCL.Desktop/Features/Settings/Views/PageSetupUpdate.axaml.cs
+++ b/PCL.Desktop/Features/Settings/Views/PageSetupUpdate.axaml.cs
@@ -578,9 +578,18 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
 
         if (this.FindControl<TextBlock>("TextChangelog") is { } changelog)
         {
-            string guide = AvaloniaLocalizationManager.GetText(
-                "Setup.Update.Changelog.Placeholder",
-                "此更新包含问题修复与改进。\n\n部分内容可能因设备、系统版本或使用方式而略有不同。建议在网络状况良好时完成下载与安装。\n\n有关此更新的完整说明与变更列表，可在 GitHub 上查看。");
+            string guide;
+            if (!string.IsNullOrWhiteSpace(result.ReleaseNotes))
+            {
+                guide = result.ReleaseNotes.Trim();
+            }
+            else
+            {
+                guide = AvaloniaLocalizationManager.GetText(
+                    "Setup.Update.Changelog.Placeholder",
+                    "此更新包含问题修复与改进。\n\n部分内容可能因设备、系统版本或使用方式而略有不同。建议在网络状况良好时完成下载与安装。\n\n有关此更新的完整说明与变更列表，可在 GitHub 上查看。");
+            }
+
             if (result.Channel is UpdateChannel.CI)
             {
                 guide += "\n\n" + AvaloniaLocalizationManager.GetText(
@@ -593,6 +602,7 @@ public partial class PageSetupUpdate : MyPageRight, IRefreshableSettingsPage, IS
                     "Setup.Update.FullOnly.NoApplicablePatch",
                     "当前安装版本没有适用的旧式补丁，将改用内容寻址分块更新。");
             }
+
             changelog.Text = guide;
         }
 

--- a/PCL.Desktop/Hosting/PluginSidecar/PluginSidecarUpdateCoordinator.cs
+++ b/PCL.Desktop/Hosting/PluginSidecar/PluginSidecarUpdateCoordinator.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 PCL N contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using PCL.Application.Updates;
+using PCL.Core.Logging;
+using PCL.Desktop.Paths;
+
+namespace PCL.Desktop.Hosting.PluginSidecar;
+
+/// <summary>
+/// Session helper for independent Sidecar CAS checks/installs. Host updates remain
+/// owned by <see cref="LauncherUpdateCoordinator"/>; this sibling never replaces the AOT body.
+/// </summary>
+internal sealed class PluginSidecarUpdateCoordinator : IDisposable
+{
+    public static PluginSidecarUpdateCoordinator Current { get; } = new();
+
+    private readonly PluginSidecarUpdateService _service = new();
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _disposed;
+
+    public async Task<PluginSidecarUpdateCheckResult> CheckAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        PluginSidecarInstallIdentity identity = PluginSidecarUpdateInstaller.ResolveLocalIdentity();
+        return await _service.CheckAsync(identity, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<string> DownloadAndInstallAsync(
+        PluginSidecarUpdateCheckResult update,
+        IProgress<double>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(update);
+        if (!update.Success || !update.IsUpdateAvailable || string.IsNullOrWhiteSpace(update.PackageUrl))
+            throw new InvalidOperationException("没有可安装的 Sidecar 更新包。");
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            string cacheRoot = Path.Combine(
+                LauncherPathLayout.ResolveCacheDirectory(),
+                "sidecar-updates");
+            Directory.CreateDirectory(cacheRoot);
+            string zipPath = Path.Combine(
+                cacheRoot,
+                (update.ReleaseName ?? "sidecar") + "-" +
+                Path.GetFileName(new Uri(update.PackageUrl).AbsolutePath));
+
+            PortableLog.Info("PluginSidecarUpdate", "开始下载 Sidecar 更新包：" + update.PackageUrl);
+            await _service.DownloadPackageAsync(update.PackageUrl, zipPath, progress, cancellationToken)
+                .ConfigureAwait(false);
+            string installed = await PluginSidecarUpdateInstaller
+                .InstallFromZipAsync(zipPath, update, cancellationToken)
+                .ConfigureAwait(false);
+            PortableLog.Info("PluginSidecarUpdate", "Sidecar 更新安装完成：" + installed);
+            return installed;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _service.Dispose();
+        _gate.Dispose();
+    }
+}

--- a/PCL.Desktop/Hosting/PluginSidecar/PluginSidecarUpdateInstaller.cs
+++ b/PCL.Desktop/Hosting/PluginSidecar/PluginSidecarUpdateInstaller.cs
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 PCL N contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using PCL.Application.Updates;
+using PCL.Core.Logging;
+using PCL.Desktop.Paths;
+
+namespace PCL.Desktop.Hosting.PluginSidecar;
+
+/// <summary>
+/// Applies an independent Sidecar CAS package without replacing the AOT host.
+/// Portable/embedded layouts extract under <c>{data}/runtime/sidecar/{hash}/</c>;
+/// scatter layouts prefer replacing <c>{installRoot}/sidecar/</c> when writable.
+/// </summary>
+internal static class PluginSidecarUpdateInstaller
+{
+    public static async Task<string> InstallFromZipAsync(
+        string zipPath,
+        PluginSidecarUpdateCheckResult update,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(zipPath);
+        ArgumentNullException.ThrowIfNull(update);
+        if (!File.Exists(zipPath))
+            throw new FileNotFoundException("Sidecar 更新包不存在。", zipPath);
+
+        string? scatterRoot = TryResolveWritableScatterSidecarRoot();
+        if (!string.IsNullOrWhiteSpace(scatterRoot))
+        {
+            string installed = await ExtractToDirectoryAsync(zipPath, scatterRoot, cancellationToken)
+                .ConfigureAwait(false);
+            await WriteStateAsync(
+                    Path.Combine(scatterRoot, ".pcl-sidecar-update.json"),
+                    update,
+                    installed,
+                    layout: "scatter")
+                .ConfigureAwait(false);
+            await RestartSidecarAsync(cancellationToken).ConfigureAwait(false);
+            PortableLog.Info("PluginSidecarUpdate", "已将 Sidecar 更新安装到散包目录：" + installed);
+            return installed;
+        }
+
+        await using FileStream zipStream = new(
+            zipPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            64 * 1024,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        string hash = Convert.ToHexStringLower(
+            await SHA256.HashDataAsync(zipStream, cancellationToken).ConfigureAwait(false));
+        zipStream.Position = 0;
+
+        string dataRoot = LauncherPathLayout.ResolveDataDirectory();
+        string runtimeRoot = Path.Combine(
+            dataRoot,
+            PclEmbeddedPluginSidecar.RelativeRuntimeFolder.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(runtimeRoot);
+        string installDir = Path.Combine(runtimeRoot, hash[..16]);
+        string exePath = await ExtractToDirectoryAsync(zipPath, installDir, cancellationToken)
+            .ConfigureAwait(false);
+        await WriteStateAsync(
+                Path.Combine(runtimeRoot, "current.json"),
+                update,
+                exePath,
+                layout: "portable",
+                contentHash: hash)
+            .ConfigureAwait(false);
+
+        PclEmbeddedPluginSidecar.InvalidateCache();
+        Environment.SetEnvironmentVariable("PCL_PLUGIN_SIDECAR_EXE", exePath);
+        Environment.SetEnvironmentVariable("PCL_PLUGIN_SIDECAR_DIR", installDir);
+        await RestartSidecarAsync(cancellationToken).ConfigureAwait(false);
+        PortableLog.Info("PluginSidecarUpdate", "已将 Sidecar 更新安装到数据目录：" + exePath);
+        return exePath;
+    }
+
+    public static PluginSidecarInstallIdentity ResolveLocalIdentity()
+    {
+        string runtimeId = PluginSidecarUpdateService.ResolveRuntimeId();
+        string variant = "SelfContained";
+        string version = "0.0.0";
+        string? commit = null;
+
+        string dataRoot = LauncherPathLayout.ResolveDataDirectory();
+        string statePath = Path.Combine(
+            dataRoot,
+            PclEmbeddedPluginSidecar.RelativeRuntimeFolder.Replace('/', Path.DirectorySeparatorChar),
+            "current.json");
+        if (File.Exists(statePath))
+        {
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(File.ReadAllText(statePath));
+                if (document.RootElement.TryGetProperty("version", out JsonElement versionNode) &&
+                    versionNode.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(versionNode.GetString()))
+                {
+                    version = versionNode.GetString()!.Trim();
+                }
+
+                if (document.RootElement.TryGetProperty("commitSha", out JsonElement commitNode) &&
+                    commitNode.ValueKind == JsonValueKind.String)
+                {
+                    commit = commitNode.GetString();
+                }
+            }
+            catch (Exception ex) when (ex is JsonException or IOException)
+            {
+                PortableLog.Debug("PluginSidecarUpdate", "读取 Sidecar current.json 失败：" + ex.Message);
+            }
+        }
+
+        return new PluginSidecarInstallIdentity(runtimeId, variant, version, commit);
+    }
+
+    private static string? TryResolveWritableScatterSidecarRoot()
+    {
+        string? installRoot = AppContext.BaseDirectory;
+        if (string.IsNullOrWhiteSpace(installRoot))
+            return null;
+
+        string sidecar = Path.Combine(installRoot, "sidecar");
+        try
+        {
+            Directory.CreateDirectory(sidecar);
+            string probe = Path.Combine(sidecar, ".write-probe-" + Guid.NewGuid().ToString("N"));
+            File.WriteAllText(probe, "ok");
+            File.Delete(probe);
+            return sidecar;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            PortableLog.Debug("PluginSidecarUpdate", "散包 sidecar 目录不可写，回退数据目录：" + ex.Message);
+            return null;
+        }
+    }
+
+    private static async Task<string> ExtractToDirectoryAsync(
+        string zipPath,
+        string installDir,
+        CancellationToken cancellationToken)
+    {
+        string tempDir = installDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                         ".tmp-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+            Directory.CreateDirectory(tempDir);
+
+            ZipFile.ExtractToDirectory(zipPath, tempDir, overwriteFiles: true);
+            string exeName = PluginSidecarPaths.ExecutableFileName;
+            if (!Directory.EnumerateFiles(tempDir, exeName, SearchOption.AllDirectories).Any())
+                throw new InvalidDataException("Sidecar 更新包缺少可执行文件：" + exeName);
+
+            if (Directory.Exists(installDir))
+                Directory.Delete(installDir, recursive: true);
+            Directory.Move(tempDir, installDir);
+            string relocated = Directory.EnumerateFiles(installDir, exeName, SearchOption.AllDirectories)
+                .FirstOrDefault()
+                ?? throw new InvalidDataException("解压后找不到 Sidecar 可执行文件。");
+            await File.WriteAllTextAsync(
+                    Path.Combine(installDir, ".extracted"),
+                    DateTimeOffset.UtcNow.ToString("O"),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return relocated;
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    private static async Task WriteStateAsync(
+        string path,
+        PluginSidecarUpdateCheckResult update,
+        string executablePath,
+        string layout,
+        string? contentHash = null)
+    {
+        string? directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        // Build via JsonObject to keep Native AOT free of reflection serializers.
+        JsonObject state = new()
+        {
+            ["version"] = update.LatestVersion,
+            ["tag"] = update.ReleaseName,
+            ["commitSha"] = update.RemoteCommitSha,
+            ["channel"] = update.Channel,
+            ["layout"] = layout,
+            ["executablePath"] = executablePath,
+            ["contentHash"] = contentHash,
+            ["installedAt"] = DateTimeOffset.UtcNow.ToString("O")
+        };
+        await File.WriteAllTextAsync(path, state.ToJsonString(new JsonSerializerOptions { WriteIndented = true }))
+            .ConfigureAwait(false);
+    }
+
+    private static async Task RestartSidecarAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await PluginSidecarSupervisor.Instance.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PortableLog.Warn("PluginSidecarUpdate", "停止旧 Sidecar 失败：" + ex.Message);
+        }
+
+        PclEmbeddedPluginSidecar.InvalidateCache();
+        bool started = await PluginSidecarSupervisor.Instance.TryStartAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (!started)
+            PortableLog.Warn("PluginSidecarUpdate", "Sidecar 更新后未能立即启动；将在下次宿主初始化时重试。");
+    }
+}

--- a/PCL.Desktop/Localization/en-US.xaml
+++ b/PCL.Desktop/Localization/en-US.xaml
@@ -1121,6 +1121,15 @@
     <sys:String x:Key="Setup.Update.FullOnly.CI">The CI channel uses content-addressed blocks and downloads only blocks missing locally.</sys:String>
     <sys:String x:Key="Setup.Update.FullOnly.NoApplicablePatch">No legacy patch applies to this build, so content-addressed blocks will be used.</sys:String>
     <sys:String x:Key="Setup.Update.Latest">PCL N Is Up to Date</sys:String>
+    <sys:String x:Key="Setup.Update.Downloaded">Update downloaded and verified</sys:String>
+    <sys:String x:Key="Setup.Update.Product.Host">PCL N software update</sys:String>
+    <sys:String x:Key="Setup.Update.Product.Plugin">Plugin feature update</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Available">A PCL.Plugin Sidecar update is available (host body is not replaced)</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Changelog.Placeholder">This update upgrades the plugin sidecar only and does not replace the Native AOT host.</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Current">Plugin</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Downloading">Downloading plugin feature update…</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Failed">Plugin feature update failed</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Installed">Plugin feature update installed; sidecar restart was attempted.</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.DownloadAndInstall">Download and install</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.DownloadOnly">Download only</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.Title">Update available</sys:String>

--- a/PCL.Desktop/Localization/zh-CN.xaml
+++ b/PCL.Desktop/Localization/zh-CN.xaml
@@ -1121,6 +1121,15 @@
     <sys:String x:Key="Setup.Update.FullOnly.CI">CI 通道使用内容寻址分块更新，只会下载本地缺少的分块。</sys:String>
     <sys:String x:Key="Setup.Update.FullOnly.NoApplicablePatch">当前安装版本没有适用的旧式补丁，将改用内容寻址分块更新。</sys:String>
     <sys:String x:Key="Setup.Update.Latest">PCL N 已是最新版本</sys:String>
+    <sys:String x:Key="Setup.Update.Downloaded">更新已下载并通过校验</sys:String>
+    <sys:String x:Key="Setup.Update.Product.Host">PCL N 软件更新</sys:String>
+    <sys:String x:Key="Setup.Update.Product.Plugin">插件功能更新</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Available">有可用的 PCL.Plugin Sidecar 更新（不替换 PCL N 本体）</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Changelog.Placeholder">此更新仅升级插件侧车与插件平台能力，不会替换 Native AOT 宿主程序。</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Current">插件</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Downloading">正在下载插件功能更新…</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Failed">插件功能更新失败</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Installed">插件功能更新已安装并尝试重启侧车。</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.DownloadAndInstall">下载并安装</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.DownloadOnly">仅下载</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.Title">发现可用更新</sys:String>

--- a/PCL.Desktop/Localization/zh-TW.xaml
+++ b/PCL.Desktop/Localization/zh-TW.xaml
@@ -1121,6 +1121,15 @@
     <sys:String x:Key="Setup.Update.FullOnly.CI">CI 通道使用內容定址分塊更新，只會下載本機缺少的分塊。</sys:String>
     <sys:String x:Key="Setup.Update.FullOnly.NoApplicablePatch">目前安裝版本沒有適用的舊式補丁，將改用內容定址分塊更新。</sys:String>
     <sys:String x:Key="Setup.Update.Latest">PCL N 已是最新版本</sys:String>
+    <sys:String x:Key="Setup.Update.Downloaded">更新已下載並通過校驗</sys:String>
+    <sys:String x:Key="Setup.Update.Product.Host">PCL N 軟體更新</sys:String>
+    <sys:String x:Key="Setup.Update.Product.Plugin">外掛功能更新</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Available">有可用的 PCL.Plugin Sidecar 更新（不替換 PCL N 本體）</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Changelog.Placeholder">此更新僅升級外掛側車與外掛平台能力，不會替換 Native AOT 宿主程式。</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Current">外掛</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Downloading">正在下載外掛功能更新…</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Failed">外掛功能更新失敗</sys:String>
+    <sys:String x:Key="Setup.Update.Plugin.Installed">外掛功能更新已安裝並嘗試重啟側車。</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.DownloadAndInstall">下載並安裝</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.DownloadOnly">僅下載</sys:String>
     <sys:String x:Key="Setup.Update.Prompt.Available.Title">發現可用更新</sys:String>

--- a/scripts/publish_plugin_sidecar_cas.ps1
+++ b/scripts/publish_plugin_sidecar_cas.ps1
@@ -1,5 +1,7 @@
 # Copyright (c) 2026 PCL N contributors.
-# Build/publish PCL.Plugin Sidecar CAS for Cloudflare (channels/plugin.json).
+# Build/publish PCL.Plugin Sidecar full-package updates for Cloudflare.
+# Sidecar updates intentionally do NOT use FastCDC block maps — only the zip +
+# channels/plugin.json marker are uploaded to R2.
 #
 # Example:
 #   .\scripts\publish_plugin_sidecar_cas.ps1 `
@@ -38,7 +40,7 @@ if (-not [string]::IsNullOrWhiteSpace($ReleaseNotesFile) -and (Test-Path -Litera
 
 $selfContained = $RuntimeVariant -eq 'SelfContained'
 $stem = "PCL_Plugin_Sidecar_${Runtime}_${RuntimeVariant}"
-$outDir = Join-Path $repoRoot "artifacts\plugin-cas\$normalizedTag"
+$outDir = Join-Path $repoRoot "artifacts\plugin-sidecar\$normalizedTag"
 New-Item -ItemType Directory -Force -Path $outDir | Out-Null
 $zipPath = Join-Path $outDir "$stem.zip"
 
@@ -58,30 +60,25 @@ if (-not (Test-Path -LiteralPath $zipPath)) {
     throw "Sidecar zip missing: $zipPath"
 }
 
-$casRoot = Join-Path $outDir 'cas'
-New-Item -ItemType Directory -Force -Path $casRoot | Out-Null
-python (Join-Path $PSScriptRoot 'generate_update_blockmap.py') `
-    --archive $zipPath `
-    --output $casRoot `
-    --target-tag $normalizedTag `
-    --target-version $normalizedVersion `
-    --runtime-id $Runtime `
-    --runtime-variant $RuntimeVariant `
-    --configuration $Configuration `
-    --profile v2
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-$generatedMaps = @(Get-ChildItem -LiteralPath $casRoot -Filter "$stem.blockmap*.json" -File -ErrorAction SilentlyContinue)
-if ($generatedMaps.Count -eq 0) {
-    $generatedMaps = @(Get-ChildItem -LiteralPath $casRoot -Filter '*.blockmap*.json' -File -ErrorAction SilentlyContinue)
+$sha256 = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+$size = (Get-Item -LiteralPath $zipPath).Length
+$metaPath = Join-Path $outDir "$stem.build.json"
+$buildMeta = [ordered]@{
+    formatVersion  = 1
+    product        = 'plugin-sidecar'
+    tag            = $normalizedTag
+    version        = $normalizedVersion
+    channel        = $Channel
+    commitSha      = $CommitSha.ToLowerInvariant()
+    runtimeId      = $Runtime
+    runtimeVariant = $RuntimeVariant
+    artifact       = "$stem.zip"
+    packageSha256  = $sha256
+    packageSize    = $size
+    delivery       = 'full-package'
+    builtAt        = (Get-Date).ToUniversalTime().ToString('o')
 }
-foreach ($map in $generatedMaps) {
-    Copy-Item -LiteralPath $map.FullName -Destination (Join-Path $outDir $map.Name) -Force
-}
-$blockmap = Join-Path $outDir "$stem.blockmap.v2.json"
-if (-not (Test-Path -LiteralPath $blockmap) -and $generatedMaps.Count -gt 0) {
-    $blockmap = Join-Path $outDir $generatedMaps[0].Name
-}
+$buildMeta | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $metaPath -Encoding utf8
 
 $channelPath = Join-Path $outDir 'plugin-channel.json'
 $marker = [ordered]@{
@@ -94,14 +91,18 @@ $marker = [ordered]@{
     manifestKey     = "channels/$Channel.json"
     releaseNotes    = $ReleaseNotes
     releaseNotesUrl = $ReleaseNotesUrl
+    packageSha256   = $sha256
+    packageSize     = $size
+    delivery        = 'full-package'
 }
 $marker | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $channelPath -Encoding utf8
 
-Write-Host "Prepared Sidecar CAS under $outDir"
-Write-Host "  zip:      $zipPath"
-Write-Host "  blockmap: $blockmap"
-Write-Host "  cas:      $casRoot"
-Write-Host "  channel:  $channelPath"
+Write-Host "Prepared Sidecar full-package update under $outDir"
+Write-Host "  zip:     $zipPath"
+Write-Host "  sha256:  $sha256"
+Write-Host "  size:    $size"
+Write-Host "  meta:    $metaPath"
+Write-Host "  channel: $channelPath"
 
 if (-not $Upload) {
     Write-Host "Skip upload (pass -Upload to push to R2)."
@@ -113,17 +114,8 @@ python (Join-Path $PSScriptRoot 'upload_r2_cas.py') put-files `
     --dir $outDir `
     --prefix $releasePrefix `
     --include "*.zip" `
-    --include "*.blockmap.v2.json" `
-    --include "*.blockmap.v2.json.asc"
+    --include "*.build.json"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-# Blocks live beside the blockmap generator output when using upload-tree from a CAS root.
-# Prefer uploading the blockmap-linked tree if present.
-$casTree = Join-Path $outDir 'cas'
-if (Test-Path -LiteralPath (Join-Path $casTree 'block')) {
-    python (Join-Path $PSScriptRoot 'upload_r2_cas.py') upload-tree --root $casTree
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-}
 
 python (Join-Path $PSScriptRoot 'upload_r2_cas.py') put `
     "channels/$Channel.json" `
@@ -131,4 +123,4 @@ python (Join-Path $PSScriptRoot 'upload_r2_cas.py') put `
     --content-type application/json
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "Uploaded Sidecar channel marker channels/$Channel.json"
+Write-Host "Uploaded Sidecar channel marker channels/$Channel.json (full-package, no blocks)."

--- a/scripts/publish_plugin_sidecar_cas.ps1
+++ b/scripts/publish_plugin_sidecar_cas.ps1
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 PCL N contributors.
+# Build/publish PCL.Plugin Sidecar CAS for Cloudflare (channels/plugin.json).
+#
+# Example:
+#   .\scripts\publish_plugin_sidecar_cas.ps1 `
+#     -Tag v0.20.1 -Version 0.20.1 -Runtime win-x64 `
+#     -ReleaseNotesFile notes.md -Upload
+
+param(
+    [Parameter(Mandatory = $true)][string]$Tag,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [string]$Runtime = 'win-x64',
+    [ValidateSet('SelfContained', 'NoRuntime')]
+    [string]$RuntimeVariant = 'SelfContained',
+    [string]$Configuration = 'Release',
+    [string]$Channel = 'plugin',
+    [string]$CommitSha = '',
+    [string]$ReleaseNotes = '',
+    [string]$ReleaseNotesFile = '',
+    [string]$ReleaseNotesUrl = '',
+    [string]$PluginTag = '',
+    [switch]$Upload,
+    [switch]$SkipFetch,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$normalizedTag = $Tag.Trim()
+if (-not $normalizedTag.StartsWith('v')) { $normalizedTag = "v$normalizedTag" }
+$normalizedVersion = $Version.Trim().TrimStart('v', 'V')
+if ([string]::IsNullOrWhiteSpace($CommitSha)) {
+    $CommitSha = (git -C $repoRoot rev-parse HEAD).Trim()
+}
+if (-not [string]::IsNullOrWhiteSpace($ReleaseNotesFile) -and (Test-Path -LiteralPath $ReleaseNotesFile)) {
+    $ReleaseNotes = Get-Content -LiteralPath $ReleaseNotesFile -Raw
+}
+
+$selfContained = $RuntimeVariant -eq 'SelfContained'
+$stem = "PCL_Plugin_Sidecar_${Runtime}_${RuntimeVariant}"
+$outDir = Join-Path $repoRoot "artifacts\plugin-cas\$normalizedTag"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+$zipPath = Join-Path $outDir "$stem.zip"
+
+if (-not $SkipBuild) {
+    $packScript = Join-Path $PSScriptRoot 'pack-plugin-sidecar-zip.ps1'
+    & $packScript `
+        -Configuration $Configuration `
+        -Runtime $Runtime `
+        -OutputZip $zipPath `
+        -PluginTag $(if ($PluginTag) { $PluginTag } else { $normalizedTag }) `
+        -SelfContained:$selfContained `
+        -SkipFetch:$SkipFetch
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+if (-not (Test-Path -LiteralPath $zipPath)) {
+    throw "Sidecar zip missing: $zipPath"
+}
+
+$casRoot = Join-Path $outDir 'cas'
+New-Item -ItemType Directory -Force -Path $casRoot | Out-Null
+python (Join-Path $PSScriptRoot 'generate_update_blockmap.py') `
+    --archive $zipPath `
+    --output $casRoot `
+    --target-tag $normalizedTag `
+    --target-version $normalizedVersion `
+    --runtime-id $Runtime `
+    --runtime-variant $RuntimeVariant `
+    --configuration $Configuration `
+    --profile v2
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$generatedMaps = @(Get-ChildItem -LiteralPath $casRoot -Filter "$stem.blockmap*.json" -File -ErrorAction SilentlyContinue)
+if ($generatedMaps.Count -eq 0) {
+    $generatedMaps = @(Get-ChildItem -LiteralPath $casRoot -Filter '*.blockmap*.json' -File -ErrorAction SilentlyContinue)
+}
+foreach ($map in $generatedMaps) {
+    Copy-Item -LiteralPath $map.FullName -Destination (Join-Path $outDir $map.Name) -Force
+}
+$blockmap = Join-Path $outDir "$stem.blockmap.v2.json"
+if (-not (Test-Path -LiteralPath $blockmap) -and $generatedMaps.Count -gt 0) {
+    $blockmap = Join-Path $outDir $generatedMaps[0].Name
+}
+
+$channelPath = Join-Path $outDir 'plugin-channel.json'
+$marker = [ordered]@{
+    formatVersion   = 1
+    tag             = $normalizedTag
+    version         = $normalizedVersion
+    channel         = $Channel
+    commitSha       = $CommitSha.ToLowerInvariant()
+    publishedAt     = (Get-Date).ToUniversalTime().ToString('o')
+    manifestKey     = "channels/$Channel.json"
+    releaseNotes    = $ReleaseNotes
+    releaseNotesUrl = $ReleaseNotesUrl
+}
+$marker | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $channelPath -Encoding utf8
+
+Write-Host "Prepared Sidecar CAS under $outDir"
+Write-Host "  zip:      $zipPath"
+Write-Host "  blockmap: $blockmap"
+Write-Host "  cas:      $casRoot"
+Write-Host "  channel:  $channelPath"
+
+if (-not $Upload) {
+    Write-Host "Skip upload (pass -Upload to push to R2)."
+    exit 0
+}
+
+$releasePrefix = "releases/$normalizedTag"
+python (Join-Path $PSScriptRoot 'upload_r2_cas.py') put-files `
+    --dir $outDir `
+    --prefix $releasePrefix `
+    --include "*.zip" `
+    --include "*.blockmap.v2.json" `
+    --include "*.blockmap.v2.json.asc"
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# Blocks live beside the blockmap generator output when using upload-tree from a CAS root.
+# Prefer uploading the blockmap-linked tree if present.
+$casTree = Join-Path $outDir 'cas'
+if (Test-Path -LiteralPath (Join-Path $casTree 'block')) {
+    python (Join-Path $PSScriptRoot 'upload_r2_cas.py') upload-tree --root $casTree
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+python (Join-Path $PSScriptRoot 'upload_r2_cas.py') put `
+    "channels/$Channel.json" `
+    $channelPath `
+    --content-type application/json
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "Uploaded Sidecar channel marker channels/$Channel.json"


### PR DESCRIPTION
## Summary
- Bind Cloudflare `releaseNotes` into the software update page and wrap long status lines (fixes truncated update info).
- Add sibling `PluginSidecarUpdateService` + layout-aware installer (portable data-dir / scatter sidecar/).
- Gate Sidecar update UI behind host being up-to-date; deliver Sidecar as **full package only** (no FastCDC blocks).
- Add `scripts/publish_plugin_sidecar_cas.ps1` for Release → R2 package → `channels/plugin.json`.
- Allow dynamic `Appearance.Cape.Name.*` localization keys in the catalog sync test (composed from Mojang aliases).

## Test plan
- [x] `PluginSidecarUpdateServiceTests`
- [x] `CheckAsync_ProductionChannelUsesCloudflareWithoutGitHubFallback` (notes)
- [x] Localization catalog sync (cape key prefix exemption)
- [ ] Manual: open 软件更新 with a long channel/RID status string and confirm wrap
- [ ] Manual: after CF channel has notes, confirm TextChangelog shows them